### PR TITLE
adding FunctionComponent symbol check

### DIFF
--- a/src/Transformer.ts
+++ b/src/Transformer.ts
@@ -152,9 +152,9 @@ export function createTransformer(
         // TODO: Check for existing propTypes assignment.
         const declaration = symbol.declarations[0] as ts.VariableDeclaration;
         const type = typeChecker.getTypeOfSymbolAtLocation(symbol, declaration) as ts.GenericType;
-
+        
         // TODO: More robust check:
-        if (!type || !type.getSymbol() || type.getSymbol().name !== 'StatelessComponent') {
+        if (!type || !type.getSymbol() || ['FunctionComponent', 'StatelessComponent'].indexOf(type.getSymbol().name) === -1) {
             return null;
         }
 

--- a/test/__snapshots__/Transformer.test.ts.snap
+++ b/test/__snapshots__/Transformer.test.ts.snap
@@ -2278,7 +2278,7 @@ var __extends = (this && this.__extends) || (function () {
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
             function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
         return extendStatics(d, b);
-    }
+    };
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }


### PR DESCRIPTION
PropTypes was missing on functional components. Checked the source code of react which states


`@deprecated` as of recent React versions, function components can no
longer be considered 'stateless'. Please use `FunctionComponent` instead.

This seems to fix the issue.